### PR TITLE
Updating the Spree::Product query to use `where`

### DIFF
--- a/lib/solidus_sitemap/solidus_defaults.rb
+++ b/lib/solidus_sitemap/solidus_defaults.rb
@@ -23,7 +23,7 @@ module SolidusSitemap::SolidusDefaults
   end
 
   def add_products(options = {})
-    active_products = Spree::Product.where(active: true).distinct
+    active_products = Spree::Product.where(deleted_at: nil).where(Spree::Product[:available_on] > 1.day.ago).distinct
 
     add(products_path, options.merge(lastmod: active_products.last_updated))
     active_products.each do |product|

--- a/lib/solidus_sitemap/solidus_defaults.rb
+++ b/lib/solidus_sitemap/solidus_defaults.rb
@@ -23,7 +23,7 @@ module SolidusSitemap::SolidusDefaults
   end
 
   def add_products(options = {})
-    active_products = Spree::Product.where(deleted_at: nil).where(Spree::Product[:available_on] > 1.day.ago).distinct
+    active_products = Spree::Product.where(deleted_at: nil).where("available_on < ?", DateTime.now).distinct
 
     add(products_path, options.merge(lastmod: active_products.last_updated))
     active_products.each do |product|

--- a/lib/solidus_sitemap/solidus_defaults.rb
+++ b/lib/solidus_sitemap/solidus_defaults.rb
@@ -23,7 +23,7 @@ module SolidusSitemap::SolidusDefaults
   end
 
   def add_products(options = {})
-    active_products = Spree::Product.active.uniq
+    active_products = Spree::Product.where(active: true).distinct
 
     add(products_path, options.merge(lastmod: active_products.last_updated))
     active_products.each do |product|


### PR DESCRIPTION
This removes the dependency on the deprecated `active` scope and will fix #4 - replacing it with `.where(deleted_at: nil).where('available_on > ?', DateTime.now)` which matches the new schema.