### PR TITLE
Update sitemap_generator to support Ruby 2.5

### DIFF
--- a/solidus_sitemap.gemspec
+++ b/solidus_sitemap.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_runtime_dependency 'solidus_core', ['>= 1.1', '< 3']
-  s.add_runtime_dependency 'sitemap_generator', '~> 5.1.0'
+  s.add_runtime_dependency 'sitemap_generator', '~> 6.0.1'
 
   s.add_development_dependency 'database_cleaner', '~> 1.4.0'
   s.add_development_dependency 'factory_bot', '~> 4.4'


### PR DESCRIPTION
Version 6.0.1 of sitemap_generator will let you generate sitemaps with Ruby 2.5 without running into:

https://github.com/kjvarga/sitemap_generator/pull/298