### PR TITLE
Replace `::each` with `::find_each` for memory usage

### DIFF
--- a/lib/solidus_sitemap/solidus_defaults.rb
+++ b/lib/solidus_sitemap/solidus_defaults.rb
@@ -26,7 +26,7 @@ module SolidusSitemap::SolidusDefaults
     available_products = Spree::Product.available.distinct
 
     add(products_path, options.merge(lastmod: available_products.last_updated))
-    available_products.each do |product|
+    available_products.find_each do |product|
       add_product(product, options)
     end
   end


### PR DESCRIPTION
`ActiveRecord::find_each` has a smaller footprint on memory usage than
`::each` when the table has a large number of records. This may be true
for the `spree_products` table.