### PR TITLE
Update dependencies

### DIFF
--- a/lib/solidus_sitemap/engine.rb
+++ b/lib/solidus_sitemap/engine.rb
@@ -4,7 +4,7 @@ require 'spree/core'
 
 module SolidusSitemap
   class Engine < Rails::Engine
-    include SolidusSupport::EngineExtensions::Decorators
+    include SolidusSupport::EngineExtensions
 
     isolate_namespace ::Spree
 

--- a/solidus_sitemap.gemspec
+++ b/solidus_sitemap.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'sitemap_generator', '~> 6.0.1'
+  s.add_dependency 'sitemap_generator', '~> 6.0'
   s.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
   s.add_dependency 'solidus_support', '~> 0.5'
 


### PR DESCRIPTION
This PR bumps e and relaxes `sitemap_generator` versions constraint to be up to date with the upstream gem changes.
To avoid warnings it also switches to the new `SolidusSupport::EngineExtensions` syntax.