### PR TITLE
Set source_code_uri in gemspec

### DIFF
--- a/solidus_sitemap.gemspec
+++ b/solidus_sitemap.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   if s.respond_to?(:metadata)
     s.metadata["homepage_uri"] = s.homepage if s.homepage
-    s.metadata["source_code_uri"] = s.homepage if s.homepage
+    s.metadata["source_code_uri"] = "https://github.com/solidusio-contrib/solidus_sitemap"
   end
 
   s.required_ruby_version = '~> 2.4'


### PR DESCRIPTION
This is used for creating the CHANGELOG automatically so it needs to be set or it won't work.

As far as I can tell this is the only thing that this needs for Solidus 3.0. When running the specs locally, all of the tests pass, and there are some skipped ones, but they aren't full specs yet.