### PR TITLE
 Relax Ruby required version to support Ruby 3.0+

### DIFF
--- a/solidus_sitemap.gemspec
+++ b/solidus_sitemap.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     s.metadata["source_code_uri"] = "https://github.com/solidusio-contrib/solidus_sitemap"
   end
 
-  s.required_ruby_version = '~> 2.4'
+  s.required_ruby_version = '>= 2.4'
 
   s.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }


### PR DESCRIPTION
This PR removes Ruby version upper limit in gemspec to make the gem work with Ruby 3.0